### PR TITLE
feat: use yarnrc to enforce yarnpkg registry

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+registry "https://registry.yarnpkg.com"


### PR DESCRIPTION
Tested by setting `npm / yarn config set registry https://registry.npmjs.com`, and regenerating `yarn.lock`. 

Packages still were sourced from `https://registry.yarnpkg.com`