### PR TITLE
feat: move explicitly required packages in index.js to dependencies, …

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   "dependencies": {
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.8.0",
+    "eslint-plugin-json-files": "^4.3.0",
+    "eslint-plugin-n": "^17.0.0",
     "globals": "^15.8.0"
   },
   "devDependencies": {
@@ -42,8 +44,6 @@
     "eslint": "^9.0.0",
     "eslint-config-crowdstrike": "10.1.0",
     "eslint-config-crowdstrike-node": "link:",
-    "eslint-plugin-json-files": "^4.3.0",
-    "eslint-plugin-n": "^17.0.0",
     "remark-cli": "^12.0.0",
     "remark-preset-lint-crowdstrike": "^4.0.0",
     "renovate-config-standard": "^2.0.0",
@@ -51,8 +51,6 @@
   },
   "peerDependencies": {
     "eslint": ">=8.57.0",
-    "eslint-config-crowdstrike": ">=1",
-    "eslint-plugin-json-files": ">=4.3.0",
-    "eslint-plugin-n": ">=16.1.0"
+    "eslint-config-crowdstrike": ">=1"
   }
 }


### PR DESCRIPTION
…from devDependencies

Since we are explicitly importing these packages into `index.js`, we should bundle them with the package now