### PR TITLE
feat: use eslintv9 compatible beta version of eslint-config-crowdstrike

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,13 @@
 'use strict';
 
-const jsonFiles = require('eslint-plugin-json-files');
+const crowdstrikeConfig = require('eslint-config-crowdstrike');
 const globals = require('globals');
-const { FlatCompat } = require('@eslint/eslintrc');
-const js = require('@eslint/js');
+const jsonFiles = require('eslint-plugin-json-files');
 const nodePlugin = require('eslint-plugin-n');
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname, // optional; default: process.cwd()
-  resolvePluginsRelativeTo: __dirname, // optional
-  recommendedConfig: js.configs.recommended, // optional unless using "eslint:recommended"
-});
 
 module.exports = [
   nodePlugin.configs['flat/recommended-script'],
-  ...compat.extends('crowdstrike'),
+  ...crowdstrikeConfig,
   {
     files: ['**/*.json'],
     plugins: {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   },
   "homepage": "https://github.com/CrowdStrike/eslint-config-crowdstrike-node#readme",
   "dependencies": {
-    "@eslint/eslintrc": "^3.1.0",
-    "@eslint/js": "^9.8.0",
+    "eslint-config-crowdstrike": "11.0.0-beta.0",
     "eslint-plugin-json-files": "^4.3.0",
     "eslint-plugin-n": "^17.0.0",
     "globals": "^15.8.0"
@@ -42,7 +41,6 @@
   "devDependencies": {
     "@crowdstrike/commitlint": "^8.0.0",
     "eslint": "^9.0.0",
-    "eslint-config-crowdstrike": "10.1.0",
     "eslint-config-crowdstrike-node": "link:",
     "remark-cli": "^12.0.0",
     "remark-preset-lint-crowdstrike": "^4.0.0",
@@ -50,7 +48,6 @@
     "standard-version": "^9.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=8.57.0",
-    "eslint-config-crowdstrike": ">=1"
+    "eslint": ">=8.57.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,7 +254,7 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@9.8.0", "@eslint/js@^9.8.0":
+"@eslint/js@9.8.0", "@eslint/js@^9.0.0":
   version "9.8.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.8.0.tgz#ae9bc14bb839713c5056f5018bcefa955556d3a4"
   integrity sha512-MfluB7EUfxXtv3i/++oh89uzAr4PDI4nn201hsp+qaXqsjAWzinlZEHEfPgAX4doIlKvPG/i0A9dpKxOLII8yA==
@@ -1258,10 +1258,12 @@ eslint-compat-utils@^0.5.1:
   version "0.0.0"
   uid ""
 
-eslint-config-crowdstrike@10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-crowdstrike/-/eslint-config-crowdstrike-10.1.0.tgz#f46fd56e4ec9b4f89d27be608aea049530db164e"
-  integrity sha512-Wy4HdaVBfe5ItXI71Szv2viO7yvX8ZMeG1TblxYy84eAYi9S2p5fMzlwU1JJUlocu7cKBS697+KWYUM8+zk6oQ==
+eslint-config-crowdstrike@11.0.0-beta.0:
+  version "11.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-crowdstrike/-/eslint-config-crowdstrike-11.0.0-beta.0.tgz#8e795d13555f4bb374e093e3bed3cc617fd13507"
+  integrity sha512-OiDvVG5wIr+ToCMlYsYdJDwMODSapsqvJ7uQ0KWeVD7cfcvibK/4SIqWAnP5BpLrNG75/QPlo4171RS5L5bepg==
+  dependencies:
+    "@eslint/js" "^9.0.0"
 
 eslint-plugin-es-x@^7.5.0:
   version "7.8.0"


### PR DESCRIPTION
* use eslintv9 compatible beta version of eslint-config-crowdstrike
* remove eslintv8 compatibility shims and packages
* bundle eslint-config-crowdstrike directly

After this change, this repo is ready to release `4.0.0`