### PR TITLE
feat: return eslint-config-crowdstrike to peer and devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "homepage": "https://github.com/CrowdStrike/eslint-config-crowdstrike-node#readme",
   "dependencies": {
-    "eslint-config-crowdstrike": "^11.0.0",
     "eslint-plugin-json-files": "^4.3.0",
     "eslint-plugin-n": "^17.0.0",
     "globals": "^15.8.0"
@@ -41,6 +40,7 @@
   "devDependencies": {
     "@crowdstrike/commitlint": "^8.0.0",
     "eslint": "^9.0.0",
+    "eslint-config-crowdstrike": "^11.0.0",
     "eslint-config-crowdstrike-node": "link:",
     "remark-cli": "^12.0.0",
     "remark-preset-lint-crowdstrike": "^4.0.0",
@@ -48,6 +48,7 @@
     "standard-version": "^9.0.0"
   },
   "peerDependencies": {
+    "eslint-config-crowdstrike": ">=1",
     "eslint": ">=8.57.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "standard-version": "^9.0.0"
   },
   "peerDependencies": {
-    "eslint-config-crowdstrike": ">=1",
+    "eslint-config-crowdstrike": ">=11",
     "eslint": ">=8.57.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,10 +254,15 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@9.8.0", "@eslint/js@^9.0.0":
+"@eslint/js@9.8.0":
   version "9.8.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.8.0.tgz#ae9bc14bb839713c5056f5018bcefa955556d3a4"
   integrity sha512-MfluB7EUfxXtv3i/++oh89uzAr4PDI4nn201hsp+qaXqsjAWzinlZEHEfPgAX4doIlKvPG/i0A9dpKxOLII8yA==
+
+"@eslint/js@^9.0.0":
+  version "9.9.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.9.0.tgz#d8437adda50b3ed4401964517b64b4f59b0e2638"
+  integrity sha512-hhetes6ZHP3BlXLxmd8K2SNgkhNSi+UcecbnwWKwpP7kyi/uC75DJ1lOOBO3xrC4jyojtGE3YxKZPHfk4yrgug==
 
 "@eslint/object-schema@^2.1.4":
   version "2.1.4"


### PR DESCRIPTION
To give developers more flexibility and choice in which version of https://github.com/CrowdStrike/eslint-config-crowdstrike they want to use, we can remove it from the shipped bundle and let developers choose which version of the ruleset they'd like to combine with this package.